### PR TITLE
adding mysql.connector as dependency for database

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ idna==3.4
 iniconfig==2.0.0
 kiwisolver==1.4.4
 matplotlib==3.6.3
+mysql-connector==2.2.9
 numpy==1.24.1
 packaging==23.0
 pandas==1.5.2


### PR DESCRIPTION
The dependency `mysql.connector` was left out when database folder was added. 

Added so that the` requirements.txt` remains complete.